### PR TITLE
Use english catalog names on AROS.

### DIFF
--- a/dist/common/YAM/Install/Install-YAM
+++ b/dist/common/YAM/Install/Install-YAM
@@ -388,8 +388,8 @@
     (select #detectedSystem "os3" "os4" "mos" "aros")
 )
 
-(if (= #detectedSystem "os4")
-    ; AmigaOS 4.x uses english locale names only
+(if (or (= #detectedSystem "os4") (= #detectedSystem "aros"))
+    ; AmigaOS 4.x and AROS use english locale names only
     (
         (set #cat_name_bosnian               "bosnian")
         (set #cat_name_czech                 "czech")


### PR DESCRIPTION
I was informed by the good people over at aros-exec that AROS, like OS4, nowadays uses english names for catalog dirs. E.g LOCALE:Catalogs/German instead of LOCALE:Catalogs/Deutsch. 