### PR TITLE
Fix for previous AmiSSL 4.7 related changes

### DIFF
--- a/src/include/libraries/amisslmaster.h
+++ b/src/include/libraries/amisslmaster.h
@@ -11,12 +11,15 @@
 #define AMISSL_V110d        0x07  /* AmiSSL v4.0 */
 #define AMISSL_V110e        0x08  /* AmiSSL v4.1 */
 #define AMISSL_V110g        0x09  /* AmiSSL v4.2 */
-#define AMISSL_V111a        0x0a  /* AmiSSL v4.3 */
+#define AMISSL_V111a_OBS    0x0a  /* AmiSSL v4.3 (obsolete incompatible API) */
+#define AMISSL_V111d        0x0b  /* AmiSSL v4.4/4.5 */
+#define AMISSL_V111g        0x0c  /* AmiSSL v4.6 */
+#define AMISSL_V111i        0x0d  /* AmiSSL v4.7 */
 
-#define AMISSL_V10x         AMISSL_V102f /* Latest AmiSSL/OpenSSL 1.0.x compatible version */
-#define AMISSL_V11x         AMISSL_V111a /* Latest AmiSSL/OpenSSL 1.1.x compatible version */
+#define AMISSL_V10x         AMISSL_V102f /* Latest minimum AmiSSL/OpenSSL 1.0.x compatible version */
+#define AMISSL_V11x         AMISSL_V110d /* Latest minimum AmiSSL/OpenSSL 1.1.x compatible version */
 
-#define AMISSL_CURRENT_VERSION   AMISSL_V11x
+#define AMISSL_CURRENT_VERSION   AMISSL_V111i
 
 #define AMISSLMASTER_MIN_VERSION 4
 

--- a/src/tcp/ssl.h
+++ b/src/tcp/ssl.h
@@ -34,12 +34,12 @@
 // forward declarations
 struct Connection;
 
-// make sure to open at least 4.3 of amisslmaster.library
+// make sure to open at least 4.4 of amisslmaster.library
 #define AMISSLMASTER_VERSION  4
-#define AMISSLMASTER_REVISION 3
+#define AMISSLMASTER_REVISION 4
 
 // AmiSSL/OpenSSL minimum version to use
-#define AMISSL_VERSION AMISSL_V111a
+#define AMISSL_VERSION AMISSL_V11x
 
 // SSL certificate verification failures
 #define SSL_CERT_ERR_NONE         (0<<0) // no error


### PR DESCRIPTION
This fix will allow YAM to use AmiSSL 4.7, 4.6, 4.5 or 4.4, and future 4.x versions. The recent changes to add AmiSSL 4.7 support by @pbobbenb were incomplete, causing YAM to still use AmiSSL 4.3.